### PR TITLE
Add SampleController with a new endpoint

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/system/SampleController.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/SampleController.java
@@ -8,6 +8,6 @@ public class SampleController {
 
     @GetMapping("/sample")
     public String getSampleResponse() {
-        return "This is a sample response";
+        return "This is a changed sample response";
     }
 }

--- a/src/main/java/org/springframework/samples/petclinic/system/SampleController.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/SampleController.java
@@ -1,0 +1,13 @@
+package org.springframework.samples.petclinic.system;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SampleController {
+
+    @GetMapping("/sample")
+    public String getSampleResponse() {
+        return "This is a sample response";
+    }
+}


### PR DESCRIPTION
This PR adds a new REST controller named `SampleController` with a `/sample` endpoint that returns a sample response.