### PR TITLE
Add SampleController with Updated Response

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/sample/SampleController.java
+++ b/src/main/java/org/springframework/samples/petclinic/sample/SampleController.java
@@ -1,0 +1,15 @@
+package org.springframework.samples.petclinic.sample;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/sample")
+public class SampleController {
+
+    @GetMapping
+    public String getSampleResponse() {
+        return "Updated Sample Response";
+    }
+}


### PR DESCRIPTION
This PR adds a new SampleController with an endpoint `/api/sample` that returns an updated sample response.